### PR TITLE
Fixed handling of Hex-STRING values + v3 support

### DIFF
--- a/snmp_simulator/simulator.py
+++ b/snmp_simulator/simulator.py
@@ -40,7 +40,11 @@ def createVariable(SuperClass, getValue, *args):
     class Var(SuperClass):
         def getValue(self, name, idx):
             oid_value, oid_type_str = getValue(name, idx)
-            return self.getSyntax().clone(TYPE_MAP[oid_type_str](oid_value))
+            if oid_type_str == 'Hex-STRING':
+                oid_value_kwarg = dict(hexValue=oid_value.replace(' ', ''))
+            else:
+                oid_value_kwarg = dict(value=oid_value)
+            return self.getSyntax().clone(TYPE_MAP[oid_type_str](**oid_value_kwarg))
     return Var(*args)
 
 

--- a/snmp_simulator/simulator.py
+++ b/snmp_simulator/simulator.py
@@ -50,6 +50,8 @@ class SNMPAgent(object):
         config.addSocketTransport(self.snmpEngine, udp.domainName, udp.UdpTransport().openServerMode((host, port)))
         config.addV1System(self.snmpEngine, 'my-area', rcommunity)
         config.addVacmUser(self.snmpEngine, 2, 'my-area', 'noAuthNoPriv', (1, 3, 6))
+        config.addV3User(self.snmpEngine, 'test')
+        config.addVacmUser(self.snmpEngine, 3, 'test', 'noAuthNoPriv', (1, 3, 6))
         self.snmpContext = context.SnmpContext(self.snmpEngine)
         self.mibBuilder = self.snmpContext.getMibInstrum().getMibBuilder()
         self.MibScalar, self.MibScalarInstance = self.mibBuilder.importSymbols('SNMPv2-SMI', 'MibScalar', 'MibScalarInstance')


### PR DESCRIPTION
The first commit adds a v3 user `test` to support SNMP v3.

The more important part of this pull request is commit https://github.com/xeemetric/snmp-simulator/commit/52a31b27a2b30de04b195990104ddaba632f25b3:

When i tried to "simulate" MIBs with Hex-STRING values in the walk file, i realized that the snmp-simulator reflects them as STRING values.
The example hex value `0x0400` is given in the walkfile as `04 00` and the snmp-simulator  passes them directly into the constructor of `OctetString`:
```
v2c.OctetString('04 00')
```
For correct processing of the hex value you have to pass it with the explicit parameter `hexValue` and remove the spaces:
```
v2c.OctetString(hexValue='0400')
```