### PR TITLE
Exposing UDP port 161

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN set -x \
     && mv /tmp/simulator/tests/cisco_2801.walk / \
     && rm -rf /tmp/simulator
 
-EXPOSE 161
+EXPOSE 161/udp
 
 CMD ["snmp-simulator", "-s", "--host", "0.0.0.0", "--port", "161", "--walk_file", "cisco_2801.walk"]


### PR DESCRIPTION
Hi,

at the moment port 161 is exposed for tcp only, which, as far as I know, is completely useless for snmp. I fixed it by switching to UDP. Hope you like it.

Cheers!